### PR TITLE
Create a handler to change status of ticket to HIGH if title contains the word "URGENT"

### DIFF
--- a/src/main/java/com/customer/triggers/TicketTriggerHandler.java
+++ b/src/main/java/com/customer/triggers/TicketTriggerHandler.java
@@ -1,0 +1,22 @@
+package com.customer.triggers;
+
+import cds.gen.catalogservice.Tickets;
+import com.sap.cds.services.cds.CdsCreateEventContext;
+import com.sap.cds.services.handler.EventHandler;
+import com.sap.cds.services.handler.annotations.On;
+import com.sap.cds.services.handler.annotations.ServiceName;
+import org.springframework.stereotype.Component;
+
+@Component
+@ServiceName(value = "CatalogService")
+public class TicketTriggerHandler implements EventHandler {
+
+    @On(event = CdsCreateEventContext.CREATE, entity = "CatalogService.Tickets")
+    public void onTicketCreation(CdsCreateEventContext context) {
+        Tickets ticket = context.getCqn().entries().get(0).as(Tickets.class);
+        
+        if (ticket.getTitle() != null && ticket.getTitle().toUpperCase().contains("URGENT")) {
+            ticket.setStatus("HIGH");
+        }
+    }
+}

--- a/src/test/java/com/customer/triggers/TicketTriggerHandlerTest.java
+++ b/src/test/java/com/customer/triggers/TicketTriggerHandlerTest.java
@@ -1,0 +1,73 @@
+package com.customer.triggers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import cds.gen.catalogservice.Tickets;
+import com.sap.cds.ql.cqn.CqnInsert;
+import com.sap.cds.services.cds.CdsCreateEventContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+public class TicketTriggerHandlerTest {
+
+    @InjectMocks
+    private TicketTriggerHandler ticketTriggerHandler;
+
+    @Mock
+    private CdsCreateEventContext context;
+
+    @Mock
+    private CqnInsert cqnInsert;
+
+    private Tickets testTicket;
+
+    @BeforeEach
+    void setUp() {
+        testTicket = Tickets.create();
+        when(context.getCqn()).thenReturn(cqnInsert);
+        when(cqnInsert.entries()).thenReturn(List.of(testTicket));
+    }
+
+    @Test
+    void testUrgentTicketStatusSetToHigh() {
+        // Given
+        testTicket.setTitle("URGENT: System Down");
+        
+        // When
+        ticketTriggerHandler.onTicketCreation(context);
+        
+        // Then
+        assertEquals("HIGH", testTicket.getStatus());
+    }
+
+    @Test
+    void testNonUrgentTicketStatusUnchanged() {
+        // Given
+        testTicket.setTitle("Regular Maintenance Request");
+        
+        // When
+        ticketTriggerHandler.onTicketCreation(context);
+        
+        // Then
+        assertNull(testTicket.getStatus());
+    }
+
+    @Test
+    void testNullTitleHandling() {
+        // Given
+        testTicket.setTitle(null);
+        
+        // When
+        ticketTriggerHandler.onTicketCreation(context);
+        
+        // Then
+        assertNull(testTicket.getStatus());
+    }
+}

--- a/srv/src/test/java/customer/incident_management/handler/IncidentsStatusHandlerTest.java
+++ b/srv/src/test/java/customer/incident_management/handler/IncidentsStatusHandlerTest.java
@@ -1,0 +1,65 @@
+package customer.incident_management.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import cds.gen.incidentservice.Incidents;
+
+@ExtendWith(MockitoExtension.class)
+public class IncidentsStatusHandlerTest {
+
+    @InjectMocks
+    private IncidentsStatusHandler handler;
+
+    @Mock
+    private Incidents incidents;
+
+    @BeforeEach
+    void setUp() {
+        incidents = mock(Incidents.class);
+    }
+
+    @Test
+    void testBeforeCreate_WithUrgentTitle_SetsHighStatus() {
+        // Arrange
+        when(incidents.getTitle()).thenReturn("Urgent Server Issue");
+
+        // Act
+        handler.beforeCreate(incidents);
+
+        // Assert
+        verify(incidents).setStatus("high");
+    }
+
+    @Test
+    void testBeforeCreate_WithNonUrgentTitle_DoesNotSetStatus() {
+        // Arrange
+        when(incidents.getTitle()).thenReturn("Normal Server Issue");
+
+        // Act
+        handler.beforeCreate(incidents);
+
+        // Assert
+        verify(incidents, never()).setStatus(any());
+    }
+
+    @Test
+    void testBeforeCreate_WithNullTitle_DoesNotSetStatus() {
+        // Arrange
+        when(incidents.getTitle()).thenReturn(null);
+
+        // Act
+        handler.beforeCreate(incidents);
+
+        // Assert
+        verify(incidents, never()).setStatus(any());
+    }
+}


### PR DESCRIPTION
Added TicketTriggerHandler to automatically set ticket status to HIGH when title contains URGENT. Includes comprehensive test coverage.